### PR TITLE
Module 2 - Prompt Engineering

### DIFF
--- a/src/actors/llm/LLMActor.ts
+++ b/src/actors/llm/LLMActor.ts
@@ -12,10 +12,10 @@ export class LLMActor {
 
   private generatePrompt(input: string): string {
     return `You are an actor in an MCP system.
-Your task is to analyze the user’s message and return ONLY one valid ActionType.
+Your task is to analyze the user’s message and return ONLY one valid ActionType, and nothing else.
 Any other kind of response will be considered invalid.
 If you are unable to identify the action, return "unknown" as the action type.
-    ActionTypes: 
+  Respond with EXACTLY one of the following ActionTypes: ${actionTypes.join(", ")}
     User's message: "${input}"
     `
   }


### PR DESCRIPTION
### Summary

This PR documents and finalizes Module 2 of the MCP Learning Journey, focusing on designing safe and evaluable prompts for LLM-based actors.

---

### What was covered

- Prompt theory: what makes a prompt structurally safe
- Comparison of multiple prompts (good vs bad)
- Manual refactor of an ambiguous prompt into a secure one
- Core lessons documented in `docs/MCP-Advanced/02-PromptEngineering.md`

---

### Why this matters

In an MCP system, the prompt is part of the logic layer.  
This module ensures prompts are treated as structured interfaces, not just instructions.

---

### Next steps

- Connect a real LLM to test the prompt against live data (Module 3)
- Add automated prompt evaluation (if needed)